### PR TITLE
Avoid apply calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class EventEmitter {
 
 		if (!listeners) {
 			this._events.set(eventName, new Set());
-			return this.on.apply(this, arguments);
+			return this.on(eventName, listener);
 		}
 
 		this.emit('newListener', eventName, listener);

--- a/index.js
+++ b/index.js
@@ -28,10 +28,6 @@ class EventEmitter {
 		return this.on(eventName, onceListenerWrapper);
 	}
 
-	addListener() {
-		return this.on.apply(this, arguments);
-	}
-
 	off(eventName, listener) {
 		const argsCount = arguments.length;
 		var listeners;
@@ -68,10 +64,6 @@ class EventEmitter {
 		return this;
 	}
 
-	removeListener() {
-		return this.off.apply(this, arguments);
-	}
-
 	removeAllListeners() {
 		return this.off();
 	}
@@ -92,5 +84,10 @@ class EventEmitter {
 		return this;
 	}
 }
+
+const EEPrototype = EventEmitter.prototype;
+
+EEPrototype.addListener = EEPrototype.on;
+EEPrototype.removeListener = EEPrototype.off;
 
 module.exports = EventEmitter;

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ class EventEmitter {
 	}
 
 	emit() {
-		const argsArray = Array.from(arguments)
+		const argsArray = Array.from(arguments);
 		const eventName = argsArray[0];
 		const listenerArgs = argsArray.slice(1);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -35,10 +35,7 @@ describe('#on', () => {
 
 describe('#addListener', () => {
   it('is an alias for #on', () => {
-    sinon.spy(e, 'on');
-    e.addListener('event', listener);
-    e.on.should.have.been.calledWith('event', listener);
-    e.on.should.have.been.calledOn(e);
+    e.addListener.should.equal(e.on);
   });
 });
 
@@ -105,10 +102,7 @@ describe('#off', () => {
 
 describe('#removeListener', () => {
   it('is an alias for #off', () => {
-    sinon.spy(e, 'off');
-    e.removeListener('event', listener);
-    e.off.should.have.been.calledWith('event', listener);
-    e.off.should.have.been.calledOn(e);
+    e.removeListener.should.equal(e.off);
   });
 });
 


### PR DESCRIPTION
* Create aliases through prototype
* Use direct call in recursive calling of method `on`